### PR TITLE
advanced synchronous publication feature

### DIFF
--- a/src/MqttConnector.cpp
+++ b/src/MqttConnector.cpp
@@ -300,6 +300,23 @@ void MqttConnector::sync_pub(String payload)
     _config.client->publish(newpub);
 }
 
+void MqttConnector::sync_advpub(String prefix, String topic, String payload, bool retain)
+{
+    //prefix is actually not yet usable
+    if (prefix != ""){
+      topic=String(_config.channelPrefix) + String("/") + String(_config.clientId)+topic;
+    }
+
+    MQTT_DEBUG_PRINT("SYNC PUB TO CHANNEL ");
+    MQTT_DEBUG_PRINT(topic.c_str());
+    MQTT_DEBUG_PRINT(".... -> ");
+    MQTT_DEBUG_PRINTLN(payload.c_str());
+
+    MQTT::Publish newpub(topic, (uint8_t*)payload.c_str(), payload.length());
+    newpub.set_retain(retain);
+    _config.client->publish(newpub);
+}
+
 void MqttConnector::loop()
 {
     if (_config.client->connected())

--- a/src/MqttConnector.h
+++ b/src/MqttConnector.h
@@ -114,6 +114,7 @@ public:
     void loop();
     void init_config(const char*, uint16_t);
     void sync_pub(String payload);
+    void sync_advpub(String prefix, String topic, String payload, bool retain);
     void clear_last_will(String payload);
     void connect();
     void publish(MQTT::Publish p) {


### PR DESCRIPTION
Not very well tested... 
For now, the topic/channel prefix setting is ignored but I'm already happy with it so I think it was worth sharing :-)
Using the example below it will publish to "/CMMC/14854185/sonar" 

```
String prefix = "/applicationprefix";
String topic = "/sonar";
String payload = "distance : 40";
mqtt->sync_advpub(prefix, topic, payload, false);
```

May be I'll fix the topic prefix thing some day but I don't have much time right now :-/