### PR TITLE
restored uniformity of topics format

### DIFF
--- a/src/MqttConnector.cpp
+++ b/src/MqttConnector.cpp
@@ -203,13 +203,13 @@ void MqttConnector::_hook_config()
 
     // subscribe
     if (_config.topicSub.length() == 0) {
-      _config.topicSub = String(_config.channelPrefix) +
+      _config.topicSub = String(_config.channelPrefix) + "/" +
         String(_config.clientId) + commandChannel;
     }
 
     // publish
     if (_config.topicPub.length() == 0) {
-      _config.topicPub = String(_config.channelPrefix) +
+      _config.topicPub = String(_config.channelPrefix) + "/" +
       String(_config.clientId) + statusChannel;
     }
 
@@ -218,7 +218,7 @@ void MqttConnector::_hook_config()
     MQTT_DEBUG_PRINT("TOPIC PUB = ");
     MQTT_DEBUG_PRINTLN(_config.topicSub);
 
-    _config.topicLastWill = String(_config.channelPrefix) +
+    _config.topicLastWill = String(_config.channelPrefix) + "/" +
       String(_config.clientId) + lwtChannel;
 
     (*info)["id"] = _config.clientId;


### PR DESCRIPTION
Topics were defined this way: /CMMC/<ID>/<topic>

Then in recent versions it turned to:

sometimes /CMMC/<ID>/<topic>,
sometimes /CMMC<ID>/<topic>

So, to be consistent, I put '/' between CMMC and the ID, for every topic
defined by the library, including the lwt topic.

Also, it helps retrocompatibility with existing applications that were
parsing the ID of the board from the topic.